### PR TITLE
TCI #1 - Add link to submit.curranindex.org

### DIFF
--- a/app/views/static_pages/_navigation.html.erb
+++ b/app/views/static_pages/_navigation.html.erb
@@ -9,6 +9,7 @@
     <%=link_to 'Attribution Scholarship', scholarship_path, class: "nav-item nav-link" %>
     <%=link_to 'Related Sites', sites_path, class: "nav-item nav-link" %>
     <%=link_to 'Contact Us', contact_path, class: "nav-item nav-link"%>
+    <%=link_to 'Submissions', 'https://submit.curranindex.org/submissions', class: "nav-item nav-link" %>
 </nav>
 </div>
 


### PR DESCRIPTION
# What this PR does

This PR should add a link to the navbar that directs the user to https://submit.curranindex.org/submissions. That domain is a Jekyll site whose design matches the main site exactly, and will simply redirect back to https://curranindex.org when the user clicks on any nav links, so the domain switching process is simple to the user.

I wasn't able to get a local build of the site running due to old dependencies, but I found the file with the navbar in it and added this link in the same pattern as the others, while consulting [this page](https://apidock.com/rails/ActionView/Helpers/UrlHelper/link_to). So, while I hope that nothing breaks, it might be good to deploy this on a test server somewhere.

# How to test

1. Go to our test site (not deployed yet)
2. Click on "Submissions" in the navbar.
3. Your browser's URL bar should now show https://submit.curranindex.org/submissions
4. Click on "Contributors"
5. Your browser's URL bar should now show https://curranindex.org/articles